### PR TITLE
security: fix 5 vulnerabilities (1c/4h) [20260429]

### DIFF
--- a/utils/lambda/package-lock.json
+++ b/utils/lambda/package-lock.json
@@ -1510,17 +1510,13 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",

--- a/utils/lambda/package.json
+++ b/utils/lambda/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.817.0",
     "mongodb": "^6.16.0"
+  },
+  "overrides": {
+    "fast-xml-parser": "4.5.4"
   }
 }

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -4471,9 +4471,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC",
       "peer": true
@@ -5662,9 +5662,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -5778,9 +5779,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -34,5 +34,10 @@
     "eslint-plugin-react": "^7.37.4",
     "license-checker": "^25.0.1",
     "prettier": "^3.5.3"
+  },
+  "overrides": {
+    "lodash": "4.18.0",
+    "flatted": "3.4.2",
+    "minimatch": "3.1.3"
   }
 }


### PR DESCRIPTION
## Security Fix Bundle — 2026-04-29

Fixes **5 Dependabot alerts** (1 critical, 4 high).

| Package | Severity | CVE/GHSA | Fixed Version | Manifest |
|---------|----------|----------|---------------|---------|
| fast-xml-parser | critical | CVE-2026-25896 | 4.5.4 | \`utils/lambda/package-lock.json\` |
| lodash | high | CVE-2026-4800 | 4.18.0 | \`web-app/package-lock.json\` |
| flatted | high | CVE-2026-33228 | 3.4.2 | \`web-app/package-lock.json\` |
| minimatch | high | CVE-2026-27903 | 3.1.3 | \`web-app/package-lock.json\` |

⚠️ **`next` (GHSA-q4gf-8mx6-v5v3) skipped** — upgrading to 15.5.15 requires React 19.2.5+ (currently 19.0.0). Needs manual dependency upgrade.

> Auto-generated by security_fix.py on 2026-04-29
> Dependabot alerts: #179, #161, #144, #134, #121, #120